### PR TITLE
Fix express type declaration error

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,8 @@
 	"author": "",
 	"license": "ISC",
 	"dependencies": {
+		"@types/express": "^4.17.21",
+		"@types/node": "^18.15.11",
 		"@vercel/node": "^5.3.17",
 		"cors": "^2.8.5",
 		"dotenv": "^16.3.1",
@@ -20,8 +22,6 @@
 	},
 	"devDependencies": {
 		"@types/dotenv": "^8.2.0",
-		"@types/express": "^4.17.21",
-		"@types/node": "^18.15.11",
 		"@types/socket.io": "^3.0.2",
 		"nodemon": "^3.0.2",
 		"ts-node": "^10.9.1",


### PR DESCRIPTION
Move `@types/express` and `@types/node` to `dependencies` to ensure TypeScript types are available during production builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-f97f5149-6fcf-46aa-a3b8-3835c0a68a28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f97f5149-6fcf-46aa-a3b8-3835c0a68a28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

